### PR TITLE
Fix summary re-assignment on tick creation for empty summary row.

### DIFF
--- a/functions/summaries.ts
+++ b/functions/summaries.ts
@@ -1,8 +1,8 @@
 import type { PluginData } from "@cloudflare/pages-plugin-cloudflare-access";
-import type { Env } from "../lib/Identity"
-import { GetIdentity } from "../lib/Identity"
+import type { Env } from "../lib/Identity";
+import { GetIdentity } from "../lib/Identity";
 import { PagesFunction } from "@cloudflare/workers-types";
-import { TimerTick } from "./ticks";
+import { TimerTick } from "../src/components/Timer/TaskRowTicks";
 
 const FULL_JSON_OBJECT_SELECT = `
   Summaries.ID, Summaries.Content, Summaries.Date, Summaries.Slot, (
@@ -19,7 +19,7 @@ const FULL_JSON_OBJECT_SELECT = `
     FROM TimerTicks TT
     WHERE TT.SummaryID = Summaries.ID
   ) as TimerTicks
-`
+`;
 
 const JsonHeader = {
   headers: {

--- a/functions/ticks.ts
+++ b/functions/ticks.ts
@@ -2,7 +2,7 @@ import type { PluginData } from "@cloudflare/pages-plugin-cloudflare-access";
 import type { Env } from "../lib/Identity"
 import { GetIdentity } from "../lib/Identity"
 import { PagesFunction } from "@cloudflare/workers-types";
-import { TimerTick } from "../src/components/Timer/TaskRow";
+import { TimerTick } from "../src/components/Timer/TaskRowTicks";
 
 const JsonHeader = {
   headers: {

--- a/functions/tsconfig.json
+++ b/functions/tsconfig.json
@@ -3,6 +3,7 @@
     "target": "esnext",
     "module": "esnext",
     "lib": ["esnext"],
+    "jsx": "react",
     "types": ["@cloudflare/workers-types"],
     "moduleResolution":"node",
   }

--- a/src/components/Timer/TaskRowSummary.tsx
+++ b/src/components/Timer/TaskRowSummary.tsx
@@ -9,9 +9,10 @@ export interface TaskRowSummaryProps {
   summary?: Summary;
   slot: number;
   useDate: number;
+  updateSummary: React.Dispatch<React.SetStateAction<Summary>>;
 };
 
-const TaskRowSummary = ({ summary, slot, useDate }: TaskRowSummaryProps) => {
+const TaskRowSummary = ({ summary, slot, useDate, updateSummary }: TaskRowSummaryProps) => {
   const [inputText, setInputText] = useState('')
 
   useEffect(() => {
@@ -20,14 +21,18 @@ const TaskRowSummary = ({ summary, slot, useDate }: TaskRowSummaryProps) => {
     }
   }, [summary]);
 
-  const setSummary = useCallback((value: string, callback = (summary: Summary) => {}) => {
-    RestApi.createSummary({Date: useDate, Content: value || "", Slot: slot} as Summary,  callback)
-  }, [slot, useDate]);
+  const setSummary = useCallback((
+    value: string,
+  ) => {
+    RestApi.createSummary({Date: useDate, Content: value || "", Slot: slot} as Summary,  updateSummary)
+  }, [slot, updateSummary, useDate]);
 
   // why useMemo? http://tiny.cc/9zd5vz
   const debouncedChangeHandler = useMemo(
-    () => debounce(event => setSummary(event.target.value), 800)
-  , [setSummary]);
+    () => debounce(event => {
+      setSummary(event.target.value);
+    }
+  , 800), [setSummary]);
 
   return (
     <div className={styles.summary_cell}>

--- a/src/components/Timer/Tick.tsx
+++ b/src/components/Timer/Tick.tsx
@@ -114,7 +114,7 @@ const Tick = ({ tickNumber, timerTick, setTick, summary, updateSummary }: TickPr
       });
     }
 
-    if (summary?.ID !== undefined) {
+    if (summary.ID !== undefined) {
       createTick(summary);
     } else {
       // We need a summaryID to associate the ticks with,


### PR DESCRIPTION
The text was being removed and unset in the db because the tick callback was naive about recent state changes.

Also fixed a couple type issues in the functions folder.