### PR TITLE
Set state on text change, clarify some names

### DIFF
--- a/src/components/Timer/TaskRowSummary.tsx
+++ b/src/components/Timer/TaskRowSummary.tsx
@@ -9,12 +9,14 @@ export interface TaskRowSummaryProps {
   summary?: Summary;
   slot: number;
   useDate: number;
-  updateSummary: React.Dispatch<React.SetStateAction<Summary>>;
+  setSummaryState: React.Dispatch<React.SetStateAction<Summary>>;
 };
 
-const TaskRowSummary = ({ summary, slot, useDate, updateSummary }: TaskRowSummaryProps) => {
-  const [inputText, setInputText] = useState('')
+const TaskRowSummary = ({ summary, slot, useDate, setSummaryState }: TaskRowSummaryProps) => {
+  const [inputText, setInputText] = useState('');
 
+  // Parent state is in charge here.
+  // Any change to the summary object needs to immediately affect input value
   useEffect(() => {
     if (summary) {
       setInputText(summary.Content);
@@ -24,8 +26,16 @@ const TaskRowSummary = ({ summary, slot, useDate, updateSummary }: TaskRowSummar
   const setSummary = useCallback((
     value: string,
   ) => {
-    RestApi.createSummary({Date: useDate, Content: value || "", Slot: slot} as Summary,  updateSummary)
-  }, [slot, updateSummary, useDate]);
+    const s = {
+      Date: useDate,
+      Content: value || "",
+      Slot: slot,
+      ID: summary.ID,
+      TimerTicks: summary.TimerTicks
+    } as Summary;
+    setSummaryState(s);
+    RestApi.createSummary(s, setSummaryState)
+  }, [summary.ID, summary.TimerTicks, useDate, slot, setSummaryState]);
 
   // why useMemo? http://tiny.cc/9zd5vz
   const debouncedChangeHandler = useMemo(

--- a/src/components/Timer/TaskRowTicks.tsx
+++ b/src/components/Timer/TaskRowTicks.tsx
@@ -8,7 +8,7 @@ export interface TaskRowTicksProps {
   summary?: Summary;
   slot: number;
   useDate: number;
-  updateSummary: React.Dispatch<React.SetStateAction<Summary>>;
+  setSummaryState: React.Dispatch<React.SetStateAction<Summary>>;
 };
 
 export type TimerTick = {
@@ -19,7 +19,7 @@ export type TimerTick = {
   SummaryID?: number;
 };
 
-const TaskRowTicks = ({ summary, updateSummary, slot, useDate }: TaskRowTicksProps) => {
+const TaskRowTicks = ({ summary, setSummaryState, slot, useDate }: TaskRowTicksProps) => {
   let ticks = new Array<JSX.Element>();
 
   for (let i = 0; i < 96; i++) {
@@ -36,8 +36,8 @@ const TaskRowTicks = ({ summary, updateSummary, slot, useDate }: TaskRowTicksPro
         summary.TimerTicks.filter((t: TimerTick) => t.TickNumber !== tick.TickNumber ) || [];
 
       summary.TimerTicks = [ ...ammendedlist, tick];
-      updateSummary(summary);
-    }, [summary, updateSummary]);
+      setSummaryState(summary);
+    }, [summary, setSummaryState]);
 
     ticks.push((
       <div className={styles.tictac_cell} key={i}>
@@ -47,7 +47,7 @@ const TaskRowTicks = ({ summary, updateSummary, slot, useDate }: TaskRowTicksPro
             tickNumber: i,
             timerTick: timerTick,
             setTick,
-            updateSummary,
+            setSummaryState,
           } }
         />
       </div>

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -36,7 +36,7 @@ const Timer = ({
   const [summaries, setSummaries] = useState(new Array<Summary>());
 
   useEffect(() => {
-    RestApi.greet(data => setIdentity(data));
+    RestApi.greet(identity => setIdentity(identity));
   }, []);
 
   useEffect(() => {
@@ -53,27 +53,27 @@ const Timer = ({
   let tickRowElements = new Array<JSX.Element>();
 
   for (let i = 0; i < 20; i++) {
-    // eslint-disable-next-line react-hooks/rules-of-hooks
     const foundSummary = summaries?.find((value) => value.Slot === i) ||
       {TimerTicks: [], Slot: i, Date: date, Content: ''} as Summary;
 
-    const updateSummary = (s: Summary) => {
+    const setSummaryState = (s: Summary) => {
+
       setSummaries([
-        s,
+        { Content: foundSummary.ID ? foundSummary.Content : s.Content, ...s },
         ...summaries.filter((_s) => _s.Slot !== i),
       ]);
     };
 
     summaryElements.push(
       <TaskRowSummary
-        { ... { updateSummary, key: i, useDate: date, slot: i }}
+        { ... { setSummaryState, key: i, useDate: date, slot: i }}
         summary={foundSummary}
       />
     )
 
     tickRowElements.push(
       <TaskRowTicks
-        { ... { updateSummary, key: i, useDate: date, slot: i }}
+        { ... { setSummaryState, key: i, useDate: date, slot: i }}
         summary={foundSummary}
       />
     )


### PR DESCRIPTION
Fixes the race between tick and summary, where a newly entered summary has a pending debounce and thus is not yet created, so the first click in that row can cause "lazy init" logic to dispatch a "create summary" with an empty text.

closes #51