### PR TITLE
fix: prevent grid cutoff on short viewports

### DIFF
--- a/src/components/Timer/Timer.module.scss
+++ b/src/components/Timer/Timer.module.scss
@@ -19,6 +19,7 @@ $tictac-gap: 2px;
     // Single scroll container for both axes — enables sticky header row
     // and sticky left/right columns simultaneously
     display: flex;
+    align-items: flex-start;
     overflow: auto;
     max-height: calc(100svh - 130px);
     position: relative;


### PR DESCRIPTION
Fixes #121

`align-items: stretch` (flex default) sizes the sticky left/right columns to the scroll-port height (`max-height`), not their row content. Their background paint stopped at the viewport boundary, leaving rows below that point unstyled when scrolled.

`align-items: flex-start` lets columns size to their natural content height so backgrounds and borders cover all rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)