### PR TITLE
fix: drop empty swatch from tick legend

### DIFF
--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -369,10 +369,6 @@ const Timer = ({
                 <span className="tt-tick-swatch tt-tick-swatch--distracted" />
                 distracted
               </span>
-              <span className="tt-tick-legend-item">
-                <span className="tt-tick-swatch tt-tick-swatch--empty" />
-                empty
-              </span>
             </div>
           )}
         </div>


### PR DESCRIPTION
## Summary
- Removes the "empty" example from the focused/distracted tick legend — two items is enough to convey meaning

## Test plan
- [x] `npm test` passes (66/66)
- [ ] Verify legend shows only focused + distracted swatches in preview

🤖 Generated with [Claude Code](https://claude.com/claude-code)