### PR TITLE
fix: mobile topbar — scope month-label absolute positioning to desktop only

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -318,9 +318,6 @@ html, body {
 /* ─── Month label (topbar center) ───────────────────────────────────────── */
 
 .tt-month-label {
-  position: absolute;
-  left: 50%;
-  transform: translateX(-50%);
   font-family: var(--font-mono);
   font-size: 0.82rem;
   font-weight: 500;
@@ -453,10 +450,14 @@ html, body {
     flex-shrink: 0;
   }
 
-  /* Push weekends toggle + legend to the far right */
   .tt-work-weekends-toggle {
     margin-top: 0;
-    margin-left: auto;
+  }
+
+  .tt-month-label {
+    position: absolute;
+    left: 50%;
+    transform: translateX(-50%);
   }
 
   .tt-tick-legend {


### PR DESCRIPTION
## Summary

- `position: absolute` on `.tt-month-label` pulled it out of flow on mobile, causing it to overlap "Sign out" and "I work weekends" in the wrapping topbar
- Moved the `position/left/transform` rules into the `@media (min-width: 900px)` block — mobile gets normal flex flow, desktop keeps the viewport-centered alignment
- Removed stale `margin-left: auto` override on `.tt-work-weekends-toggle` in the desktop block (leftover from its old sub-header position)

## Test plan

- [x] 112 specs pass
- [x] Diff coverage clean
- [x] Verify in Chrome DevTools mobile emulation — topbar flows without overlap
- [x] Verify desktop: month label still locks to viewport center above date cluster

> ⚠️ Screenshot required before merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)