### PR TITLE
feat: auto-navigate to today on foreground after 6h idle or day rollover

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect } from 'react';
+import React, { useEffect, useRef } from 'react';
 import { useNavigate, useSearchParams } from 'react-router-dom';
 
 import Timer from './components/Timer/Timer';
 
 const ONE_DAY_MILLIS = 86400000;
+const IDLE_THRESHOLD_MS = 6 * 60 * 60 * 1000; // 6 hours
 
 export const todaysDateInt = () => {
   const now = new Date();
@@ -26,6 +27,31 @@ function App({ useDate = todaysDateInt() }: AppProps) {
   const [searchParams] = useSearchParams();
   const date = parseInt(searchParams.get('date') ?? useDate.toString());
   const navigate = useNavigate();
+
+  // Refs persist across effect re-runs so we don't lose the hidden timestamp
+  // when the date changes (which re-runs the effect and would reset local vars).
+  const hiddenAtRef = useRef<number | null>(null);
+  const hiddenTodayRef = useRef<number | null>(null);
+
+  useEffect(() => {
+    const handler = () => {
+      if (document.visibilityState === 'hidden') {
+        hiddenAtRef.current = Date.now();
+        hiddenTodayRef.current = todaysDateInt();
+      } else if (document.visibilityState === 'visible' && hiddenAtRef.current !== null) {
+        const elapsed = Date.now() - hiddenAtRef.current;
+        const nowToday = todaysDateInt();
+        const dayRolled = nowToday !== hiddenTodayRef.current;
+        hiddenAtRef.current = null;
+        hiddenTodayRef.current = null;
+        if ((dayRolled || elapsed >= IDLE_THRESHOLD_MS) && date !== nowToday) {
+          navigate(`/timer?date=${nowToday}`);
+        }
+      }
+    };
+    document.addEventListener('visibilitychange', handler);
+    return () => document.removeEventListener('visibilitychange', handler);
+  }, [date, navigate]);
 
   useEffect(() => {
     const handler = (e: KeyboardEvent) => {

--- a/src/components/Timer/Timer.cy.tsx
+++ b/src/components/Timer/Timer.cy.tsx
@@ -545,6 +545,32 @@ describe('<Timer />', () => {
     cy.get('h2').should('contain', 'Thu, Mar 23');
   });
 
+  it('auto-navigates to today when foregrounded after 6+ hours on a past date', () => {
+    const now = TIME_NOW - 420 * 60 * 1000;
+    cy.clock(now + new Date().getTimezoneOffset() * 60 * 1000);
+
+    cy.intercept('GET', `/summaries?date=${TODAYS_DATE - ONE_DAY}`, { fixture: 'summariesPast' }).as('prevDay');
+    cy.intercept('GET', `/summaries?date=${TODAYS_DATE}`, { fixture: 'summaries' }).as('backToday');
+    cy.intercept('GET', /\/summaries\?startDate=/, { body: [] });
+
+    cy.get("[data-test-id='left-nav-clicker']").click();
+    cy.wait('@prevDay');
+    cy.get('h2').should('contain', 'Wed, Mar 22');
+
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'hidden', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+    cy.tick(6 * 60 * 60 * 1000);
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'visible', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    cy.wait('@backToday');
+    cy.get('h2').should('contain', 'Thu, Mar 23');
+  });
+
   it('keyboard shortcuts do not fire when a summary input is focused', () => {
     cy.get("[data-test-id='summary-text-0']").focus();
     cy.get('body').trigger('keydown', { key: 'ArrowLeft', bubbles: true });

--- a/src/components/Timer/Timer.localStorage.cy.tsx
+++ b/src/components/Timer/Timer.localStorage.cy.tsx
@@ -483,6 +483,62 @@ describe('<Timer /> using localStorage', () => {
     cy.get("[data-test-id='today-btn']").should('not.exist');
   });
 
+  it('auto-navigates to today when foregrounded after 6+ hours on a past date', () => {
+    cy.clock(TODAYS_DATE + new Date().getTimezoneOffset() * 60 * 1000);
+
+    cy.get("[data-test-id='left-nav-clicker']").click();
+    cy.get('h2').should('contain', 'Wed, Mar 22');
+
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'hidden', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+    cy.tick(6 * 60 * 60 * 1000);
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'visible', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    cy.get('h2').should('contain', 'Thu, Mar 23');
+  });
+
+  it('auto-navigates to new today when foregrounded after midnight on any view', () => {
+    cy.clock(TODAYS_DATE + new Date().getTimezoneOffset() * 60 * 1000);
+
+    // Hide while on today
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'hidden', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+    // Advance 24h — todaysDateInt() now returns TODAYS_DATE + ONE_DAY (Fri Mar 24)
+    cy.tick(86400000);
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'visible', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    cy.get('h2').should('contain', 'Fri, Mar 24');
+  });
+
+  it('does not auto-navigate when foregrounded within 6 hours on the same day', () => {
+    cy.clock(TODAYS_DATE + new Date().getTimezoneOffset() * 60 * 1000);
+
+    cy.get("[data-test-id='left-nav-clicker']").click();
+    cy.get('h2').should('contain', 'Wed, Mar 22');
+
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'hidden', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+    cy.tick(2 * 60 * 60 * 1000); // only 2 hours
+    cy.document().then((doc) => {
+      Object.defineProperty(doc, 'visibilityState', { value: 'visible', configurable: true });
+      doc.dispatchEvent(new Event('visibilitychange'));
+    });
+
+    cy.get('h2').should('contain', 'Wed, Mar 22');
+  });
+
   it('ArrowLeft key navigates to the previous day in localStorage mode', () => {
     cy.get('body').trigger('keydown', { key: 'ArrowLeft', bubbles: true });
     cy.get('h2').should('contain', 'Wed, Mar 22');


### PR DESCRIPTION
## Summary

When the user backgrounds the app (tab switch, phone lock, PWA suspend) and returns either on a **different calendar day** or after **≥ 6 hours**, the interface now automatically navigates to today — no manual action required.

Covers the key case: opens the PWA fresh on Monday morning after a non-working weekend; the app was last viewed on Friday and auto-advances to Monday.

**Implementation** (`App.tsx`):
- `visibilitychange` listener stores `hiddenAt` and `hiddenTodayInt` in **refs** (not state/locals) so the values survive effect re-runs when `date` changes
- On `visible`: fires `navigate(/timer?date=today)` if `dayRolled || elapsed >= 6h`, guarded by `date !== todaysDateInt()` to skip no-op navigations when already on today

## Test plan

- [x] `auto-navigates to today when foregrounded after 6+ hours on a past date` — localStorage + cloud specs
- [x] `auto-navigates to new today when foregrounded after midnight on any view` — localStorage spec
- [x] `does not auto-navigate when foregrounded within 6 hours on the same day` — localStorage spec
- [x] 116 specs pass, diff coverage clean

> ⚠️ Screenshot / manual verification required before merge — open app on a past date, background for 6h (or mock with DevTools), foreground and confirm redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)