### PR TITLE
feat: add Google Calendar import with busy time display

### DIFF
--- a/functions/calendar.ts
+++ b/functions/calendar.ts
@@ -1,0 +1,146 @@
+import type { Env } from '../lib/Identity';
+import { GetIdentity } from '../lib/Identity';
+
+interface CalendarEvent {
+  id: string;
+  summary: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  status?: 'confirmed' | 'tentative' | 'cancelled';
+  colorId?: string;
+  location?: string;
+  description?: string;
+}
+
+const JsonHeader = {
+  headers: {
+    'content-type': 'application/json;charset=UTF-8',
+  },
+};
+
+const errorResponse = (error: string) =>
+  new Response(JSON.stringify({ error }), JsonHeader);
+
+const formatCalendarEvent = (googleEvent: any): CalendarEvent => {
+  const start = googleEvent.start.dateTime || googleEvent.start.date;
+  const end = googleEvent.end.dateTime || googleEvent.end.date;
+
+  return {
+    id: googleEvent.id,
+    summary: googleEvent.summary || 'No Title',
+    start,
+    end,
+    allDay: !!googleEvent.start.date,
+    status: googleEvent.status as 'confirmed' | 'tentative' | 'cancelled',
+    colorId: googleEvent.colorId,
+    location: googleEvent.location,
+    description: googleEvent.description,
+  };
+};
+
+export const onRequest: PagesFunction<Env, never> = async ({ env, request }) => {
+  const { identity, error } = await GetIdentity(request, env);
+
+  if (error) return errorResponse(error);
+  if (!identity) return errorResponse('Unexpected Null Identity');
+
+  const url = new URL(request.url);
+  const startDate = url.searchParams.get('startDate');
+  const endDate = url.searchParams.get('endDate');
+
+  if (!startDate || !endDate) {
+    return errorResponse('startDate and endDate parameters required');
+  }
+
+  // Get OAuth token for user
+  const tokenResult = await env.DB.prepare(
+    `SELECT accessToken, refreshToken, expiresAt FROM OAuthTokens
+     WHERE userId = ? AND provider = 'google'`
+  ).bind(identity.userId).first<{ accessToken: string; refreshToken: string; expiresAt: number }>();
+
+  if (!tokenResult) {
+    return errorResponse('Calendar not connected');
+  }
+
+  let accessToken = tokenResult.accessToken;
+  let shouldRefresh = false;
+
+  if (Date.now() >= tokenResult.expiresAt) {
+    shouldRefresh = true;
+  }
+
+  if (shouldRefresh && tokenResult.refreshToken) {
+    const tokenEndpoint = 'https://oauth2.googleapis.com/token';
+    const refreshResponse = await fetch(tokenEndpoint, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        client_id: env.GOOGLE_OAUTH_CLIENT,
+        client_secret: env.GOOGLE_OAUTH_SECRET,
+        refresh_token: tokenResult.refreshToken,
+        grant_type: 'refresh_token',
+      }),
+    });
+
+    if (!refreshResponse.ok) {
+      return errorResponse('Failed to refresh calendar token');
+    }
+
+    const refreshData = await refreshResponse.json<{
+      access_token: string;
+      expires_in: number;
+    }>();
+
+    accessToken = refreshData.access_token;
+
+    const newExpiresAt = Date.now() + (refreshData.expires_in - 5 * 60) * 1000;
+    await env.DB.prepare(
+      `UPDATE OAuthTokens SET accessToken = ?, expiresAt = ?, updatedAt = CURRENT_TIMESTAMP
+       WHERE userId = ? AND provider = 'google'`
+    ).bind(accessToken, newExpiresAt, identity.userId);
+  }
+
+  try {
+    const timeMin = new Date(parseInt(startDate)).toISOString();
+    const timeMax = new Date(parseInt(endDate)).toISOString();
+
+    const calendarUrl = `https://www.googleapis.com/calendar/v3/calendars/primary/events?timeMin=${encodeURIComponent(timeMin)}&timeMax=${encodeURIComponent(timeMax)}&singleEvents=true&orderBy=startTime`;
+
+    const calendarResponse = await fetch(calendarUrl, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!calendarResponse.ok) {
+      const errorData = await calendarResponse.json();
+      return errorResponse(errorData.error?.message || 'Failed to fetch calendar events');
+    }
+
+    const calendarData = await calendarResponse.json<{ items: any[] }>();
+
+    const events = calendarData.items
+      .filter((e) => e.status !== 'cancelled')
+      .map(formatCalendarEvent);
+
+    return new Response(
+      JSON.stringify(
+        {
+          events,
+          meta: {
+            fetchedAt: new Date().toISOString(),
+            count: events.length,
+          },
+        },
+        null,
+        2
+      ),
+      JsonHeader
+    );
+  } catch (err) {
+    return errorResponse(`Error fetching calendar: ${(err as Error).message}`);
+  }
+};

--- a/functions/callback.ts
+++ b/functions/callback.ts
@@ -1,5 +1,14 @@
 import { Env, TASKER_COOKIE, parseCookies, AppIdentity } from '../lib/Identity';
 
+interface GoogleTokenResponse {
+  id_token: string;
+  access_token: string;
+  expires_in: number;
+  refresh_token?: string;
+  scope: string;
+  token_type: string;
+}
+
 import jwtDecode from 'jwt-decode';
 
 const JsonHeader = {
@@ -47,7 +56,7 @@ export const onRequest: PagesFunction<Env, never> = async ({
       grant_type: 'authorization_code',
     }),
   });
-  const { id_token } = await tokenResponse.json<{ id_token: string }>();
+  const { id_token, access_token, expires_in, refresh_token } = await tokenResponse.json<GoogleTokenResponse>();
 
   // This is server context, we called google direct over TLS, no need to validate further
   if (id_token && id_token !== '') {
@@ -93,6 +102,18 @@ export const onRequest: PagesFunction<Env, never> = async ({
       return errorResponse(
         'unable to find newly inserted user/identity records'
       );
+
+    // Store OAuth tokens for calendar API access
+    const expiresAt = Date.now() + (expires_in - 5 * 60) * 1000;
+    await env.DB.prepare(`
+      INSERT INTO OAuthTokens (userId, provider, accessToken, refreshToken, expiresAt)
+      VALUES (?, 'google', ?, ?, ?)
+      ON CONFLICT(userId, provider) DO UPDATE SET
+        accessToken = excluded.accessToken,
+        refreshToken = excluded.refreshToken,
+        expiresAt = excluded.expiresAt,
+        updatedAt = CURRENT_TIMESTAMP
+    `).bind(user.id, access_token, refresh_token ?? '', expiresAt);
 
     // 3. insert new session based on securely random session id
     const mySession = crypto.randomUUID();

--- a/functions/greet.ts
+++ b/functions/greet.ts
@@ -62,7 +62,7 @@ export const onRequest: PagesFunction<Env, never> = async ({
   url.search = [
     ['client_id', env.GOOGLE_OAUTH_CLIENT],
     ['response_type', 'code'],
-    ['scope', 'openid email'],
+    ['scope', 'openid email https://www.googleapis.com/auth/calendar.readonly'],
     ['state', mySession],
     ['nonce', crypto.randomUUID()],
     ['redirect_uri', redirectUri],

--- a/migrations/0011_store-oauth-tokens.sql
+++ b/migrations/0011_store-oauth-tokens.sql
@@ -1,0 +1,16 @@
+-- Migration number: 0011 	 2026-07-12
+DROP TABLE IF EXISTS OAuthTokens;
+CREATE TABLE OAuthTokens (
+  id INTEGER PRIMARY KEY,
+  userId INT NOT NULL,
+  provider TEXT NOT NULL,
+  accessToken TEXT NOT NULL,
+  refreshToken TEXT,
+  expiresAt INTEGER NOT NULL,
+  createdAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+  updatedAt DATETIME DEFAULT CURRENT_TIMESTAMP,
+  FOREIGN KEY (userId) REFERENCES Users(id),
+  UNIQUE(userId, provider)
+);
+
+CREATE INDEX OAuthTokensUser ON OAuthTokens (userId);

--- a/src/LocalStorageApi.ts
+++ b/src/LocalStorageApi.ts
@@ -2,6 +2,7 @@ import { Summary } from '../functions/summaries';
 import { UserPreferences } from '../functions/preferences';
 import { synthesizeTick } from './components/Timer/Timer.actions';
 import { TickChangeEvent } from './components/Timer/Timer.slice';
+import { CalendarEvent } from './RestApi';
 
 export const localStoragePrefix = 'TimelyTasker:';
 const PREFERENCES_KEY = localStoragePrefix + 'Preferences';
@@ -144,7 +145,12 @@ const reorderSummaries = (date: number, orderedIds: number[], storage = localSto
     resolve(reordered);
   });
 
-const exports = { createTick, getSummaries, createSummary, getPreferences, setPreference, reorderSummaries };
+const getCalendarEvents = /* istanbul ignore next */ (): Promise<{ events: CalendarEvent[]; meta: { fetchedAt: string; count: number } }> =>
+  new Promise((resolve) => {
+    resolve({ events: [], meta: { fetchedAt: new Date().toISOString(), count: 0 } });
+  });
+
+const exports = { createTick, getSummaries, createSummary, getPreferences, setPreference, reorderSummaries, getCalendarEvents };
 
 export type StorageApiType = typeof exports;
 

--- a/src/RestApi.ts
+++ b/src/RestApi.ts
@@ -148,6 +148,41 @@ const reorderPinnedTasks = (orderedIds: number[]): Promise<PinnedTask[]> =>
 
 export { getPinnedTasks, setPinnedTask, removePinnedTask, updatePinnedTaskText, reorderPinnedTasks };
 
+// Calendar API types
+export interface CalendarEvent {
+  id: string;
+  summary: string;
+  start: string;
+  end: string;
+  allDay: boolean;
+  status?: 'confirmed' | 'tentative' | 'cancelled';
+  colorId?: string;
+  location?: string;
+  description?: string;
+}
+
+export interface CalendarApiResponse {
+  events: CalendarEvent[];
+  meta: {
+    fetchedAt: string;
+    count: number;
+  };
+}
+
+const getCalendarEvents = (startDate: number, endDate: number) =>
+  fetch(
+    fetchPrefix + `/calendar?startDate=${startDate}&endDate=${endDate}`,
+    fetchOptions
+  )
+    .then((response) => response.json<CalendarApiResponse | { error: string }>())
+    .then((data) => {
+      if (!Array.isArray(data) && data?.error === 'invalid user session')
+        throw new Error('session_expired');
+      return data as CalendarApiResponse;
+    });
+
+export { getCalendarEvents };
+
 const reorderSummaries = (date: number, orderedIds: number[]): Promise<Summary[]> =>
   fetch(fetchPrefix + '/summaries', {
     ...fetchOptions,

--- a/src/components/MonthView/MonthView.module.scss
+++ b/src/components/MonthView/MonthView.module.scss
@@ -154,6 +154,37 @@ $dot-size: 6px;
   text-overflow: ellipsis;
 }
 
+.calendarCol {
+  display: flex;
+  gap: 4px;
+  align-items: center;
+  overflow: hidden;
+  padding-left: 8px;
+  border-left: 1px solid var(--color-surface-border);
+}
+
+.calendarEvent {
+  width: 8px;
+  height: 8px;
+  border-radius: 2px;
+  flex-shrink: 0;
+  border: 1px solid rgba(255, 255, 255, 0.2);
+
+  &:hover {
+    opacity: 0.8;
+  }
+}
+
+.calendarError {
+  text-align: center;
+  color: var(--color-distracted);
+  font-size: 0.75rem;
+  padding: 12px;
+  background: rgba(214, 136, 85, 0.05);
+  border-radius: 4px;
+  margin: 0 16px;
+}
+
 .loading {
   text-align: center;
   color: var(--color-text-muted);

--- a/src/components/MonthView/MonthView.tsx
+++ b/src/components/MonthView/MonthView.tsx
@@ -2,6 +2,7 @@ import React, { useEffect, useState } from 'react';
 import { Link, useSearchParams } from 'react-router-dom';
 import RestApi from '../../RestApi';
 import { Summary } from '../../../functions/summaries';
+import { CalendarEvent } from '../../RestApi';
 import styles from './MonthView.module.scss';
 
 const ONE_DAY = 86400000;
@@ -78,10 +79,12 @@ const taskNames = (summaries: Summary[]) =>
 interface DayData {
   date: number;
   summaries: Summary[];
+  calendarEvents: CalendarEvent[];
 }
 
 interface RangeApi {
   getSummariesRange: (startDate: number, endDate: number) => Promise<Summary[]>;
+  getCalendarEvents?: (startDate: number, endDate: number) => Promise<any>;
 }
 
 interface MonthViewProps {
@@ -99,24 +102,54 @@ const MonthView = ({ useApi: propApi }: MonthViewProps) => {
   const [days, setDays] = useState<DayData[]>([]);
   const [loading, setLoading] = useState(true);
   const [sessionExpired, setSessionExpired] = useState(false);
+  const [calendarError, setCalendarError] = useState<string | null>(null);
 
   useEffect(() => {
     setLoading(true);
     setSessionExpired(false);
+    setCalendarError(null);
 
     const allDays: number[] = [];
     for (let d = monthStart; d <= monthEnd; d += ONE_DAY) allDays.push(d);
 
-    useApi
-      .getSummariesRange(monthStart, monthEnd)
-      .then((summaries) => {
+    Promise.all([
+      useApi.getSummariesRange(monthStart, monthEnd),
+      useApi.getCalendarEvents?.(monthStart, monthEnd).catch((err) => {
+        console.warn('Calendar fetch failed:', err);
+        setCalendarError((err as Error).message);
+        return null;
+      }),
+    ])
+      .then(([summaries, calendarData]) => {
         const byDate = new Map<number, Summary[]>();
         summaries.forEach((s) => {
           const bucket = byDate.get(s.date) ?? [];
           bucket.push(s);
           byDate.set(s.date, bucket);
         });
-        setDays(allDays.map((d) => ({ date: d, summaries: byDate.get(d) ?? [] })));
+
+        const eventsByDate = new Map<number, CalendarEvent[]>();
+        if (calendarData?.events) {
+          calendarData.events.forEach((event: CalendarEvent) => {
+            const start = new Date(event.start).getTime();
+            const end = new Date(event.end).getTime();
+            for (let d = monthStart; d <= monthEnd; d += ONE_DAY) {
+              if (start < d + ONE_DAY && end > d) {
+                const dayEvents = eventsByDate.get(d) ?? [];
+                dayEvents.push(event);
+                eventsByDate.set(d, dayEvents);
+              }
+            }
+          });
+        }
+
+        setDays(
+          allDays.map((d) => ({
+            date: d,
+            summaries: byDate.get(d) ?? [],
+            calendarEvents: eventsByDate.get(d) ?? [],
+          }))
+        );
         setLoading(false);
       })
       .catch((err) => {
@@ -186,12 +219,13 @@ const MonthView = ({ useApi: propApi }: MonthViewProps) => {
             <span className={styles.hoursCol}>Focused</span>
             <span className={styles.tasksCol}>Tasks</span>
           </div>
-          {days.map(({ date, summaries }) => {
+          {days.map(({ date, summaries, calendarEvents }) => {
             const fh = focusedHours(summaries);
             const names = taskNames(summaries);
             const hs = hourStates(summaries);
             const isEmpty = summaries.length === 0;
             const isToday = date === today;
+            const hasCalendarEvents = calendarEvents.length > 0;
             return (
               <Link
                 key={date}
@@ -211,9 +245,25 @@ const MonthView = ({ useApi: propApi }: MonthViewProps) => {
                 <span className={styles.tasksCol}>
                   {names.length > 0 ? names.join(', ') : ''}
                 </span>
+                {hasCalendarEvents && (
+                  <span className={styles.calendarCol} aria-hidden>
+                    {calendarEvents.map((event, idx) => (
+                      <span
+                        key={idx}
+                        className={styles.calendarEvent}
+                        title={`${event.summary} (${new Date(event.start).toLocaleTimeString([], { hour: '2-digit', minute: '2-digit' })})`}
+                      />
+                    ))}
+                  </span>
+                )}
               </Link>
             );
           })}
+          {calendarError && (
+            <div className={styles.calendarError}>
+              Calendar events unavailable: {calendarError}
+            </div>
+          )}
         </div>
       )}
     </div>

--- a/src/components/Timer/TaskRowTicks.tsx
+++ b/src/components/Timer/TaskRowTicks.tsx
@@ -2,33 +2,77 @@ import React from 'react';
 import styles from './Timer.module.scss';
 import Tick from './Tick';
 import { Summary } from '../../../functions/summaries';
+import { CalendarEvent } from '../../RestApi';
 import { StorageApiType } from '../../LocalStorageApi';
+
+// Google Calendar colors mapping
+const calendarColors: Record<string, string> = {
+  '1': '#ac725e',
+  '2': '#d68855',
+  '3': '#e5b842',
+  '4': '#83a846',
+  '5': '#4d9c9a',
+  '6': '#4279a8',
+  '7': '#8a6fa8',
+  '8': '#666666',
+  '9': '#d66d75',
+  '10': '#b68a42',
+  '11': '#72c697',
+};
+
+const getCalendarColor = (colorId?: string) => {
+  return colorId && calendarColors[colorId] ? calendarColors[colorId] : '#4279a8';
+};
+
+const formatTime = (isoString: string) => {
+  const date = new Date(isoString);
+  return date.toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit' });
+};
 
 export interface TaskRowTicksProps {
   slot: number;
   useApi: StorageApiType;
+  calendarEvents?: CalendarEvent[];
 }
 
-export type TimerTick = {
-  id?: number;
-  userId?: number;
-  tickNumber: number;
-  distracted?: number;
-  summaryId?: number;
-  summary?: Summary;
-};
-
-const TaskRowTicks = ({ slot, useApi }: TaskRowTicksProps) => {
+const TaskRowTicks = ({ slot, useApi, calendarEvents = [] }: TaskRowTicksProps) => {
   const ticks = new Array<JSX.Element>();
 
+  // Build tick-to-event mapping for this slot's date
+  const tickEvents: Record<number, CalendarEvent[]> = {};
+  calendarEvents.forEach((event) => {
+    const start = new Date(event.start).getTime();
+    const end = new Date(event.end).getTime();
+    const eventStartTick = Math.floor((start % 86400000) / (15 * 60000));
+    const eventEndTick = Math.floor((end % 86400000) / (15 * 60000));
+    for (let t = Math.max(0, eventStartTick); t < Math.min(96, eventEndTick); t++) {
+      if (!tickEvents[t]) tickEvents[t] = [];
+      tickEvents[t].push(event);
+    }
+  });
+
   for (let tickNumber = 0; tickNumber < 96; tickNumber++) {
+    const eventsForTick = tickEvents[tickNumber] || [];
     ticks.push(
       <div className={styles.tictac_cell} key={tickNumber}>
+        {eventsForTick.length > 0 && (
+          <div className={styles.calendar_marker}>
+            {eventsForTick.map((evt, idx) => (
+              <span
+                key={idx}
+                className={styles.calendar_marker_dot}
+                style={{ backgroundColor: getCalendarColor(evt.colorId) }}
+                title={`${evt.summary} (${formatTime(evt.start)} - ${formatTime(evt.end)})`}
+              />
+            ))}
+          </div>
+        )}
         <Tick
           {...{
             slot,
             tickNumber,
             useApi,
+            hasCalendarMarker: eventsForTick.length > 0,
           }}
         />
       </div>

--- a/src/components/Timer/Timer.cy.tsx
+++ b/src/components/Timer/Timer.cy.tsx
@@ -31,6 +31,7 @@ beforeEach(() => {
   cy.intercept('GET', '/preferences', { body: {} }).as('getPreferences');
   cy.intercept('POST', '/preferences', (req) => { req.reply({ body: req.body }); }).as('setPreference');
   cy.intercept('GET', '/pinnedTasks', { body: [] }).as('getPinnedTasks');
+  cy.intercept('GET', '/calendar*', { body: { events: [], meta: { fetchedAt: new Date().toISOString(), count: 0 } } }).as('getCalendar');
 
   cy.window().then((win) =>
     win.localStorage.setItem('TimelyTasker:UseLocalStorage', 'no')

--- a/src/components/Timer/Timer.cy.tsx
+++ b/src/components/Timer/Timer.cy.tsx
@@ -8,6 +8,7 @@ import summarySlotThree from '../../../cypress/fixtures/summarySlotThree.json';
 import { Provider } from 'react-redux';
 import storeMaker from '../../store';
 import { MemoryRouter, Route, Routes } from 'react-router-dom';
+import RestApi from '../../RestApi';
 
 const TODAYS_DATE = 1679529600000; // at the zero h:m:s  (Thu March 23, 2023)
 const TIME_NOW = 1679587374481; // at 9 am
@@ -1077,5 +1078,25 @@ describe('<Timer />', () => {
     );
     cy.wait(['@getIdentity', '@getYesterdayForReorder']);
     cy.get('[data-test-id="drag-handle-0"]').should('not.exist');
+  });
+
+  it('handles connect calendar button click', () => {
+    const greetStub = cy.stub(RestApi, 'greet').as('greetStub');
+
+    cy.mount(
+      <Provider store={storeMaker()}>
+        <MemoryRouter>
+          <Routes>
+            <Route path="/" element={<App useDate={TODAYS_DATE} />} />
+          </Routes>
+        </MemoryRouter>
+      </Provider>
+    );
+
+    // Click the Connect Calendar button
+    cy.get('[data-test-id="calendar-settings-btn"]').click();
+
+    // Verify that RestApi.greet was called
+    cy.get('@greetStub').should('have.been.calledOnce');
   });
 });

--- a/src/components/Timer/Timer.module.scss
+++ b/src/components/Timer/Timer.module.scss
@@ -533,3 +533,34 @@ $tictac-gap: 2px;
   35%      { transform: rotateZ(-4deg); }
   40%, 100% { transform: rotateZ(0); }
 }
+
+// ─── Calendar events ────────────────────────────────────────────────────────
+
+.calendar_marker {
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  right: 2px;
+  display: flex;
+  gap: 2px;
+  pointer-events: none;
+
+  .calendar_marker_dot {
+    flex: 1;
+    height: 4px;
+    border-radius: 1px;
+    opacity: 0.6;
+
+    &:hover {
+      opacity: 0.9;
+    }
+  }
+}
+
+.grid_ticks {
+  position: relative;
+
+  .tictac_cell {
+    position: relative;
+  }
+}

--- a/src/components/Timer/Timer.module.scss
+++ b/src/components/Timer/Timer.module.scss
@@ -564,3 +564,200 @@ $tictac-gap: 2px;
     position: relative;
   }
 }
+
+// ─── Calendar Settings Panel ────────────────────────────────────────────────
+
+.calendar_settings_overlay {
+  position: fixed;
+  top: 0;
+  left: 0;
+  right: 0;
+  bottom: 0;
+  background: rgba(0, 0, 0, 0.5);
+  z-index: 1000;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 16px;
+}
+
+.calendar_settings_panel {
+  background: var(--color-surface-raised);
+  border: 1px solid var(--color-surface-border);
+  border-radius: 8px;
+  box-shadow: 0 8px 32px rgba(0, 0, 0, 0.5);
+  max-width: 400px;
+  width: 100%;
+  font-family: var(--font-sans);
+}
+
+.calendar_panel {
+  padding: 16px;
+
+  .calendar_panel_header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    padding: 8px;
+    border-bottom: 1px solid var(--color-surface-border);
+
+    span {
+      font-weight: 500;
+      color: var(--color-text-primary);
+    }
+
+    .calendar_panel_close {
+      background: none;
+      border: none;
+      cursor: pointer;
+      font-size: 1.2rem;
+      line-height: 1;
+      color: var(--color-text-muted);
+      padding: 2px 4px;
+      &:hover { color: var(--color-text-primary); }
+    }
+  }
+
+  .calendar_panel_body {
+    padding: 16px 8px;
+
+    .calendar_status_connected {
+      display: flex;
+      align-items: center;
+      gap: 6px;
+      color: var(--color-text-primary);
+      font-size: 0.85rem;
+      margin-bottom: 8px;
+
+      .calendar_dot {
+        width: 8px;
+        height: 8px;
+        border-radius: 50%;
+        background: #34A853;
+        box-shadow: 0 0 4px rgba(52, 168, 83, 0.5);
+      }
+    }
+
+    .calendar_desc {
+      color: var(--color-text-secondary);
+      font-size: 0.85rem;
+      line-height: 1.4;
+      margin-bottom: 16px;
+    }
+
+    .calendar_connect_btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      width: 100%;
+      padding: 8px 12px;
+      border-radius: 4px;
+      border: none;
+      background: #4285F4;
+      color: white;
+      font-weight: 500;
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: background 0.2s;
+
+      &:hover { background: #3367D6; }
+    }
+
+    .calendar_disconnect_btn {
+      display: flex;
+      align-items: center;
+      justify-content: center;
+      gap: 8px;
+      width: 100%;
+      padding: 8px 12px;
+      border-radius: 4px;
+      border: 1px solid rgba(248, 113, 113, 0.3);
+      background: transparent;
+      color: #f87171;
+      font-weight: 500;
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s;
+
+      &:hover {
+        background: rgba(248, 113, 113, 0.08);
+        border-color: #f87171;
+      }
+    }
+  }
+
+  .calendar_panel_footer {
+    padding: 8px;
+    border-top: 1px solid var(--color-surface-border);
+
+    .calendar_help_link {
+      display: block;
+      text-align: center;
+      color: var(--color-text-muted);
+      font-size: 0.78rem;
+      text-decoration: none;
+      transition: color 0.2s;
+
+      &:hover { color: var(--color-accent); }
+    }
+  }
+}
+
+// ─── Disconnect Prompt ──────────────────────────────────────────────────────
+
+.disconnect_prompt {
+  padding: 20px;
+
+  h3 {
+    margin: 0 0 8px;
+    color: var(--color-text-primary);
+    font-size: 1rem;
+  }
+
+  p {
+    margin: 0 0 16px;
+    color: var(--color-text-secondary);
+    font-size: 0.85rem;
+    line-height: 1.4;
+  }
+
+  .disconnect_actions {
+    display: flex;
+    gap: 8px;
+    justify-content: flex-end;
+
+    .btn_cancel {
+      padding: 6px 12px;
+      border-radius: 4px;
+      border: 1px solid var(--color-surface-border);
+      background: transparent;
+      color: var(--color-text-secondary);
+      font-size: 0.82rem;
+      cursor: pointer;
+      transition: border-color 0.2s, color 0.2s;
+
+      &:hover {
+        border-color: var(--color-text-muted);
+        color: var(--color-text-primary);
+      }
+    }
+
+    .btn_disconnect {
+      padding: 6px 12px;
+      border-radius: 4px;
+      border: 1px solid rgba(248, 113, 113, 0.3);
+      background: rgba(248, 113, 113, 0.1);
+      color: #f87171;
+      font-size: 0.82rem;
+      font-weight: 500;
+      cursor: pointer;
+      transition: background 0.2s, border-color 0.2s;
+
+      &:hover {
+        background: rgba(248, 113, 113, 0.2);
+        border-color: #f87171;
+      }
+    }
+  }
+}

--- a/src/components/Timer/Timer.selectors.ts
+++ b/src/components/Timer/Timer.selectors.ts
@@ -1,11 +1,15 @@
 import { createSelector } from '@reduxjs/toolkit';
 import { Summary } from '../../../functions/summaries';
 import { TimerTick } from './TaskRowTicks';
+import { CalendarEvent } from '../../RestApi';
 
 export const getSummaries = (store): { [slot: number]: Summary } =>
   store.timer.summaries;
+export const getCalendarEvents = (store): { [date: number]: CalendarEvent[] } =>
+  store.timer.calendarEvents;
 export const getLoadingDate = (store) => store.timer.loadingDate;
 export const getSessionExpired = (store): boolean => store.timer.sessionExpired;
+export const getCalendarLoading = (store) => store.timer.calendarLoading;
 
 export const getSummary = createSelector(
   [getSummaries, (state, slot: number) => slot],
@@ -47,5 +51,12 @@ export const getMatchingTicks = createSelector(
       });
     });
     return matching;
+  }
+);
+
+export const getCalendarEventsForDate = createSelector(
+  [getCalendarEvents, (state, date: number) => date],
+  (calendarEvents, date): CalendarEvent[] => {
+    return calendarEvents[date] || [];
   }
 );

--- a/src/components/Timer/Timer.slice.ts
+++ b/src/components/Timer/Timer.slice.ts
@@ -4,19 +4,24 @@ import { Summary } from '../../../functions/summaries';
 import { ApiStates, RestApiStatus } from '../../RestApi';
 import { TimerTick } from './TaskRowTicks';
 import { TickState } from './Tick';
+import { CalendarEvent } from '../../RestApi';
 
 export interface TimerState {
   summaries: { [slot: number]: Summary };
+  calendarEvents: { [date: number]: CalendarEvent[] };
   loadingDate?: number;
   summariesLoading: RestApiStatus;
   summaryCreated: RestApiStatus;
+  calendarLoading: RestApiStatus;
   sessionExpired: boolean;
 }
 
 const initialState = {
   summaries: {},
+  calendarEvents: {},
   summariesLoading: ApiStates.Initial,
   summaryCreated: ApiStates.Initial,
+  calendarLoading: ApiStates.Initial,
   sessionExpired: false,
 } as TimerState;
 
@@ -95,6 +100,23 @@ const slice = createSlice({
         TimerTicks: tickArray,
       };
     },
+
+    calendarEventsLoaded: (
+      state,
+      action: PayloadAction<{ date: number; events: CalendarEvent[] }>
+    ) => {
+      state.calendarEvents[action.payload.date] = action.payload.events;
+      state.calendarLoading = ApiStates.Success;
+    },
+
+    calendarEventsLoading: (state, action: PayloadAction<number>) => {
+      state.calendarLoading = ApiStates.InProgress;
+      state.loadingDate = action.payload;
+    },
+
+    calendarEventsError: (state) => {
+      state.calendarLoading = ApiStates.Error;
+    },
   },
 });
 
@@ -109,5 +131,8 @@ export const {
   summaryPending,
   summaryError,
   tickUpdated,
+  calendarEventsLoaded,
+  calendarEventsLoading,
+  calendarEventsError,
 } = slice.actions;
 export default slice.reducer;

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -114,6 +114,11 @@ const Timer = ({
 
   const useApi = useLocal === USELOCAL.YES ? LocalStorageApi : RestApi;
 
+  // Calendar state
+  const [isCalendarConnected, setIsCalendarConnected] = useState(false);
+  const [showCalendarSettings, setShowCalendarSettings] = useState(false);
+  const [showDisconnectConfirm, setShowDisconnectConfirm] = useState(false);
+
   const [pinnedTasks, setPinnedTasksState] = useState<PinnedTask[]>([]);
   const autoPopulatedPins = useRef<Set<string>>(new Set());
 
@@ -498,6 +503,18 @@ const Timer = ({
               />
               I work weekends
             </label>
+          )}
+          {useLocal === USELOCAL.NO && (
+            <button
+              onClick={() => setShowCalendarSettings(true)}
+              className="tt-btn tt-btn-ghost"
+              data-test-id="calendar-settings-btn"
+            >
+              <svg width="12" height="12" viewBox="0 0 24 24" fill="#4285F4" style={{ marginRight: '4px' }}>
+                <path d="M19 3H5c-1.1 0-2 .9-2 2v14c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2V5c0-1.1-.9-2-2-2zm0 16H5V5h14v14z"/>
+              </svg>
+              {isCalendarConnected ? 'Calendar' : 'Connect Calendar'}
+            </button>
           )}
         </div>
         {useLocal === USELOCAL.NO ? (

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -47,71 +47,6 @@ const Header = () => {
   return <div className={styles.tictac_header_row}>{items}</div>;
 };
 
-// ─── Calendar Settings Panel Component ──────────────────────────────────────
-
-interface CalendarSettingsProps {
-  isConnected: boolean;
-  onConnect: () => void;
-  onDisconnect: () => void;
-  onClose: () => void;
-}
-
-const CalendarSettings = ({ isConnected, onConnect, onDisconnect, onClose }: CalendarSettingsProps) => {
-  return (
-    <div className={styles.calendar_panel} data-test-id="calendar-panel">
-      <div className={styles.calendar_panel_header}>
-        <span>Google Calendar</span>
-        <button onClick={onClose} className={styles.calendar_panel_close} title="Close" data-test-id="calendar-panel-close">
-          ×
-        </button>
-      </div>
-      <div className={styles.calendar_panel_body}>
-        {isConnected ? (
-          <>
-            <p className={styles.calendar_status_connected}>
-              <span className={styles.calendar_dot} />
-              Connected
-            </p>
-            <p className={styles.calendar_desc}>
-              Your calendar events will appear as colored markers on the timer grid.
-            </p>
-            <button
-              onClick={onDisconnect}
-              className={styles.calendar_disconnect_btn}
-              data-test-id="calendar-disconnect-btn"
-            >
-              Disconnect Calendar
-            </button>
-          </>
-        ) : (
-          <>
-            <p className={styles.calendar_desc}>
-              Import your Google Calendar events to see when you're busy on the timer grid.
-            </p>
-            <button
-              onClick={onConnect}
-              className={styles.calendar_connect_btn}
-              data-test-id="calendar-connect-btn"
-            >
-              Connect Google Calendar
-            </button>
-          </>
-        )}
-      </div>
-      <div className={styles.calendar_panel_footer}>
-        <a
-          href="https://github.com/readysetawesome/timely-tasker#readme"
-          target="_blank"
-          rel="noopener noreferrer"
-          className={styles.calendar_help_link}
-        >
-          Learn more
-        </a>
-      </div>
-    </div>
-  );
-};
-
 export interface TimerProps {
   date: number;
   currentTime: Date;
@@ -266,6 +201,63 @@ const Timer = ({
 
   const handleCancelDisconnect = () => {
     setShowDisconnectConfirm(false);
+  };
+
+  // Calendar settings panel component
+  const CalendarSettings = ({ isConnected, onConnect, onDisconnect, onClose }: { isConnected: boolean; onConnect: () => void; onDisconnect: () => void; onClose: () => void }) => {
+    return (
+      <div className={styles.calendar_panel} data-test-id="calendar-panel">
+        <div className={styles.calendar_panel_header}>
+          <span>Google Calendar</span>
+          <button onClick={onClose} className={styles.calendar_panel_close} title="Close" data-test-id="calendar-panel-close">
+            ×
+          </button>
+        </div>
+        <div className={styles.calendar_panel_body}>
+          {isConnected ? (
+            <>
+              <p className={styles.calendar_status_connected}>
+                <span className={styles.calendar_dot} />
+                Connected
+              </p>
+              <p className={styles.calendar_desc}>
+                Your calendar events will appear as colored markers on the timer grid.
+              </p>
+              <button
+                onClick={onDisconnect}
+                className={styles.calendar_disconnect_btn}
+                data-test-id="calendar-disconnect-btn"
+              >
+                Disconnect Calendar
+              </button>
+            </>
+          ) : (
+            <>
+              <p className={styles.calendar_desc}>
+                Import your Google Calendar events to see when you're busy on the timer grid.
+              </p>
+              <button
+                onClick={onConnect}
+                className={styles.calendar_connect_btn}
+                data-test-id="calendar-connect-btn"
+              >
+                Connect Google Calendar
+              </button>
+            </>
+          )}
+        </div>
+        <div className={styles.calendar_panel_footer}>
+          <a
+            href="https://github.com/readysetawesome/timely-tasker#readme"
+            target="_blank"
+            rel="noopener noreferrer"
+            className={styles.calendar_help_link}
+          >
+            Learn more
+          </a>
+        </div>
+      </div>
+    );
   };
 
   useEffect(() => {

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -764,40 +764,6 @@ const Timer = ({
           )}
           {!summariesError && useLocal !== null && (
             <>
-              {/* ── Calendar Settings Modal ── */}
-              {showCalendarSettings && (
-                <div className={styles.calendar_settings_overlay} onClick={() => setShowCalendarSettings(false)}>
-                  <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
-                    <CalendarSettings
-                      isConnected={isCalendarConnected}
-                      onConnect={handleCalendarConnect}
-                      onDisconnect={handleCalendarDisconnect}
-                      onClose={() => setShowCalendarSettings(false)}
-                    />
-                  </div>
-                </div>
-              )}
-
-              {/* ── Disconnect Confirmation ── */}
-              {showDisconnectConfirm && (
-                <div className={styles.calendar_settings_overlay} onClick={handleCancelDisconnect} data-test-id="calendar-disconnect-overlay">
-                  <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
-                    <div className={styles.disconnect_prompt} data-test-id="calendar-disconnect-prompt">
-                      <h3>Disconnect Calendar?</h3>
-                      <p>Calendar events will no longer be imported from your Google Calendar.</p>
-                      <div className={styles.disconnect_actions}>
-                        <button onClick={handleCancelDisconnect} className={styles.btn_cancel} data-test-id="calendar-disconnect-cancel">
-                          Cancel
-                        </button>
-                        <button onClick={handleConfirmDisconnect} className={styles.btn_disconnect} data-test-id="calendar-disconnect-confirm">
-                          Disconnect
-                        </button>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
               <div className={styles.left_column} data-test-id="timer-left-column">
                 <div key="headerspacer" className={styles.summary_header}>
                   <span>Task</span>
@@ -864,6 +830,40 @@ const Timer = ({
         </div>
       </div>
       </DragProvider>
+
+      {/* ── Calendar Settings Modal ── */}
+      {showCalendarSettings && (
+        <div className={styles.calendar_settings_overlay} onClick={() => setShowCalendarSettings(false)}>
+          <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
+            <CalendarSettings
+              isConnected={isCalendarConnected}
+              onConnect={handleCalendarConnect}
+              onDisconnect={handleCalendarDisconnect}
+              onClose={() => setShowCalendarSettings(false)}
+            />
+          </div>
+        </div>
+      )}
+
+      {/* ── Disconnect Confirmation ── */}
+      {showDisconnectConfirm && (
+        <div className={styles.calendar_settings_overlay} onClick={handleCancelDisconnect} data-test-id="calendar-disconnect-overlay">
+          <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
+            <div className={styles.disconnect_prompt} data-test-id="calendar-disconnect-prompt">
+              <h3>Disconnect Calendar?</h3>
+              <p>Calendar events will no longer be imported from your Google Calendar.</p>
+              <div className={styles.disconnect_actions}>
+                <button onClick={handleCancelDisconnect} className={styles.btn_cancel} data-test-id="calendar-disconnect-cancel">
+                  Cancel
+                </button>
+                <button onClick={handleConfirmDisconnect} className={styles.btn_disconnect} data-test-id="calendar-disconnect-confirm">
+                  Disconnect
+                </button>
+              </div>
+            </div>
+          </div>
+        </div>
+      )}
     </div>
   );
 };

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -584,7 +584,10 @@ const Timer = ({
           )}
           {useLocal === USELOCAL.NO && (
             <button
-              onClick={() => setShowCalendarSettings(true)}
+              onClick={(e) => {
+                console.log('Calendar button clicked!');
+                setShowCalendarSettings(true);
+              }}
               className="tt-btn tt-btn-ghost"
               data-test-id="calendar-settings-btn"
             >

--- a/src/components/Timer/Timer.tsx
+++ b/src/components/Timer/Timer.tsx
@@ -47,6 +47,71 @@ const Header = () => {
   return <div className={styles.tictac_header_row}>{items}</div>;
 };
 
+// ─── Calendar Settings Panel Component ──────────────────────────────────────
+
+interface CalendarSettingsProps {
+  isConnected: boolean;
+  onConnect: () => void;
+  onDisconnect: () => void;
+  onClose: () => void;
+}
+
+const CalendarSettings = ({ isConnected, onConnect, onDisconnect, onClose }: CalendarSettingsProps) => {
+  return (
+    <div className={styles.calendar_panel} data-test-id="calendar-panel">
+      <div className={styles.calendar_panel_header}>
+        <span>Google Calendar</span>
+        <button onClick={onClose} className={styles.calendar_panel_close} title="Close" data-test-id="calendar-panel-close">
+          ×
+        </button>
+      </div>
+      <div className={styles.calendar_panel_body}>
+        {isConnected ? (
+          <>
+            <p className={styles.calendar_status_connected}>
+              <span className={styles.calendar_dot} />
+              Connected
+            </p>
+            <p className={styles.calendar_desc}>
+              Your calendar events will appear as colored markers on the timer grid.
+            </p>
+            <button
+              onClick={onDisconnect}
+              className={styles.calendar_disconnect_btn}
+              data-test-id="calendar-disconnect-btn"
+            >
+              Disconnect Calendar
+            </button>
+          </>
+        ) : (
+          <>
+            <p className={styles.calendar_desc}>
+              Import your Google Calendar events to see when you're busy on the timer grid.
+            </p>
+            <button
+              onClick={onConnect}
+              className={styles.calendar_connect_btn}
+              data-test-id="calendar-connect-btn"
+            >
+              Connect Google Calendar
+            </button>
+          </>
+        )}
+      </div>
+      <div className={styles.calendar_panel_footer}>
+        <a
+          href="https://github.com/readysetawesome/timely-tasker#readme"
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.calendar_help_link}
+        >
+          Learn more
+        </a>
+      </div>
+    </div>
+  );
+};
+
 export interface TimerProps {
   date: number;
   currentTime: Date;
@@ -180,6 +245,27 @@ const Timer = ({
     RestApi.greet((res: IdentityResponse) => {
       if (res.authorizeUrl) window.location.href = res.authorizeUrl;
     });
+  };
+
+  const handleCalendarConnect = () => {
+    // Trigger re-auth with calendar scope
+    RestApi.greet((res: IdentityResponse) => {
+      if (res.authorizeUrl) window.location.href = res.authorizeUrl;
+    });
+  };
+
+  const handleCalendarDisconnect = () => {
+    setShowDisconnectConfirm(true);
+  };
+
+  const handleConfirmDisconnect = async () => {
+    setIsCalendarConnected(false);
+    setShowDisconnectConfirm(false);
+    setShowCalendarSettings(false);
+  };
+
+  const handleCancelDisconnect = () => {
+    setShowDisconnectConfirm(false);
   };
 
   useEffect(() => {
@@ -678,6 +764,40 @@ const Timer = ({
           )}
           {!summariesError && useLocal !== null && (
             <>
+              {/* ── Calendar Settings Modal ── */}
+              {showCalendarSettings && (
+                <div className={styles.calendar_settings_overlay} onClick={() => setShowCalendarSettings(false)}>
+                  <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
+                    <CalendarSettings
+                      isConnected={isCalendarConnected}
+                      onConnect={handleCalendarConnect}
+                      onDisconnect={handleCalendarDisconnect}
+                      onClose={() => setShowCalendarSettings(false)}
+                    />
+                  </div>
+                </div>
+              )}
+
+              {/* ── Disconnect Confirmation ── */}
+              {showDisconnectConfirm && (
+                <div className={styles.calendar_settings_overlay} onClick={handleCancelDisconnect} data-test-id="calendar-disconnect-overlay">
+                  <div className={styles.calendar_settings_panel} onClick={(e) => e.stopPropagation()}>
+                    <div className={styles.disconnect_prompt} data-test-id="calendar-disconnect-prompt">
+                      <h3>Disconnect Calendar?</h3>
+                      <p>Calendar events will no longer be imported from your Google Calendar.</p>
+                      <div className={styles.disconnect_actions}>
+                        <button onClick={handleCancelDisconnect} className={styles.btn_cancel} data-test-id="calendar-disconnect-cancel">
+                          Cancel
+                        </button>
+                        <button onClick={handleConfirmDisconnect} className={styles.btn_disconnect} data-test-id="calendar-disconnect-confirm">
+                          Disconnect
+                        </button>
+                      </div>
+                    </div>
+                  </div>
+                </div>
+              )}
+
               <div className={styles.left_column} data-test-id="timer-left-column">
                 <div key="headerspacer" className={styles.summary_header}>
                   <span>Task</span>


### PR DESCRIPTION
- Calendar events imported from Google Calendar API
- Events displayed as colored markers on timer grid and MonthView
- OAuth scope expanded to include calendar.readonly
- OAuth tokens stored server-side with refresh support

## Summary



## Test plan

- [ ] `npm test` passes locally
- [ ] CI passes

## Checklist

- [ ] **OAuth**: If this branch needs Google login on its Cloudflare preview URL, register the following in the [Google OAuth client config](https://console.cloud.google.com/auth/clients/520908376805-qng7l5f1sj9s0mq7brelq74lalmskdpk.apps.googleusercontent.com?project=timely-tasker):
  - `https://YOUR-BRANCH-NAME.timely-tasker.pages.dev`
  - `https://YOUR-BRANCH-NAME.timely-tasker.pages.dev/callback`
- [ ] If tick state encoding or schema changed, fixtures and both test files updated
- [ ] Both storage modes tested (cloud + localStorage)
